### PR TITLE
Correct error with NA values

### DIFF
--- a/R/facet_zoom.R
+++ b/R/facet_zoom.R
@@ -97,13 +97,13 @@ FacetZoom <- ggproto("FacetDuplicate", Facet,
             cbind(data, PANEL = 1L),
             if ('x' %in% layout$name) {
                 index_x <- tryCatch(lazy_eval(params$x, data), error = function(e) FALSE)
-                if (sum(index_x) != 0) {
+                if (sum(index_x, na.rm = TRUE) != 0) {
                     cbind(data[index_x, ], PANEL = layout$PANEL[layout$name == "x"])
                 }
             },
             if ('y' %in% layout$name) {
                 index_y <- tryCatch(lazy_eval(params$y, data), error = function(e) FALSE)
-                if (sum(index_y) != 0) {
+                if (sum(index_y, na.rm = TRUE) != 0) {
                     cbind(data[index_y, ], PANEL = layout$PANEL[layout$name == "y"])
                 }
             }


### PR DESCRIPTION
Bug introduced in e2d3ab7
In the case where some values are NA
```
ggplot(data.frame(x = c(1, 2, NA, 4), y = c(4, 5, 6, 7)), aes(x, y)) +
     geom_point() +
     facet_zoom(x = x < 3)
```

Throws an error:
'Error in if (sum(index_x) != 0) { : missing value where TRUE/FALSE needed"