### PR TITLE
*_link2: fix groupwise interpolation

### DIFF
--- a/R/link.R
+++ b/R/link.R
@@ -161,10 +161,11 @@ StatLink2 <- ggproto('StatLink2', Stat,
         extraCols <- !names(data) %in% c('x', 'y', 'group', 'PANEL', 'frame')
         data <- data %>% group_by_(~group) %>%
             do({
-                interp <- tween_t(list(.$x, .$y), n)
+                n_group <- n * (nrow(.)-1) + 1
+                interp <- tween_t(list(.$x, .$y), n_group)
                 interp <- data.frame(x = interp[[1]], y = interp[[2]])
                 interp <- cbind(interp,
-                                index = seq(0, 1, length.out = n),
+                                index = seq(0, 1, length.out = n_group),
                                 group = .$group[1],
                                 PANEL = .$PANEL[1])
                 if ('frame' %in% names(.)) interp$frame <- .$frame[1]


### PR DESCRIPTION
In the *_link2, the interpolation was done with a fixed size in each group. This was leading to some error if the size of the group and the interpolated size were incompatible (cf tweenr doc). A simple fix was to define the interpolated size as n*(nrow(group)-1) + 1 instead of n. Note that this is coherent with *_link in which each line is interpolated into n lines.