### PR TITLE
Cleanup in stat_sina() code, and remove limitation on `maxwidth`

### DIFF
--- a/R/sina.R
+++ b/R/sina.R
@@ -184,7 +184,7 @@ StatSina <- ggproto("StatSina", Stat,
   setup_params = function(data, params) {
     #Limit maxwidth to 0.96 to leave some space between groups
     if (!is.null(params$maxwidth))
-      params$maxwidth <- (min(abs(params$maxwidth), .96))
+      params$maxwidth <- abs(params$maxwidth) # needs to be positive
     else
       params$maxwidth <- 0.96
 
@@ -243,18 +243,10 @@ StatSina <- ggproto("StatSina", Stat,
 
       #confine the samples in a (-maxwidth/2, -maxwidth/2) area around the
       #group's center
-      if (max(densities$y) > 0.5 * maxwidth)
-        intra_scaling_factor <- 0.5 * maxwidth / max(densities$y)
-      else
-        intra_scaling_factor <- (0.5 * maxwidth) / max(densities$y)
-
+      intra_scaling_factor <- 0.5 * maxwidth / max(densities$y)
     } else {
-      #allow up to 50 samples in a bin without scaling
-      if (max(bin_counts) > 50 * maxwidth) {
-        intra_scaling_factor <- 50 * maxwidth / max(bin_counts)
-      } else
-        intra_scaling_factor <- (50 * maxwidth) / max(bin_counts)
-      }
+      intra_scaling_factor <- 0.5 * maxwidth / max(bin_counts)
+    }
 
     for (i in names(bin_counts)) {
       #examine bins with more than 'bin_limit' samples
@@ -268,7 +260,7 @@ StatSina <- ggproto("StatSina", Stat,
         if (method == "density")
           xmax <- mean(densities$y[findInterval(densities$x, cur_bin) == 1])
         else
-          xmax <- bin_counts[i] / 100
+          xmax <- bin_counts[i]
 
         #assign the samples uniformely within the specified range
         x_translation <- stats::runif(bin_counts[i], - xmax, xmax)


### PR DESCRIPTION
This pull request does two things:

1. It cleans up some code in `stat_sina` that makes no sense. In two cases, `if`/`else` codepaths execute the exact same code, so there's no need for the `if`/`else` construct.

2. It removes the artificial limit on the `maxwidth` parameter. I provide an example below for a situation where `maxwidth > 1` is appropriate.

```
n <- 200
y1 <- rnorm(n, mean = 5, sd = 3.5)
y2 <- rnorm(n, mean = 12, sd = .4)
y3 <- rnorm(n, mean = 3.5, sd = 2)

df <- data.frame(y = c(y1, y2, y3), x = rep(c("A", "B", "C"), each = n))

ggplot(df, aes(x, y)) + stat_sina(maxwidth = 1.5)
```

<img width="749" alt="screen shot 2017-08-13 at 1 56 49 pm" src="https://user-images.githubusercontent.com/4210929/29252670-f694166a-8030-11e7-852c-92958ff3bb14.png">
