### PR TITLE
Increase the minimum version of ggplot2 to 3.0.0

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -15,7 +15,7 @@ BugReports: https://github.com/thomasp85/ggforce/issues
 License: GPL (>=2)
 LazyData: TRUE
 Depends:
-    ggplot2 (>= 2.2.0),
+    ggplot2 (>= 3.0.0),
     R (>= 3.3.0)
 Imports:
     Rcpp (>= 0.12.2),


### PR DESCRIPTION
`scale_type()` is exported in https://github.com/tidyverse/ggplot2/commit/ac3245a79d4c41e7777e62d7a933a5eb6ccb0bbc, which is included in the version >=3.0.0 of ggplot2. So, if the version is pre-3.0.0, the installation of ggforce fails with this error:

```
Error : object 'scale_type' is not exported by 'namespace:ggplot2'
```