### PR TITLE
set default val for asp.ratio arg in stat_delvor_summary()

### DIFF
--- a/R/voronoi.R
+++ b/R/voronoi.R
@@ -515,7 +515,7 @@ StatDelvorSummary <- ggproto('StatDelvorSummary', Stat,
 stat_delvor_summary <- function(mapping = NULL, data = NULL, geom = 'point',
                                 position = 'identity', na.rm = FALSE,
                                 bound = NULL, eps = 1e-9, normalize = FALSE,
-                                asp.ratio = asp.ratio, show.legend = NA,
+                                asp.ratio = 1, show.legend = NA,
                                 inherit.aes = TRUE, ...) {
   layer(
     data = data, mapping = mapping, stat = StatDelvorSummary, geom = geom,


### PR DESCRIPTION
`stat_delvor_summary()` is hitting an error due to a recursive default argument:

``` r
library(ggforce)
#> Loading required package: ggplot2
ggplot(iris, aes(Sepal.Length, Sepal.Width, group = -1L)) +
  stat_delvor_summary()
#> Error in layer(data = data, mapping = mapping, stat = StatDelvorSummary, : promise already under evaluation: recursive default argument reference or earlier problems?
```

<sup>Created on 2019-10-26 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0)</sup>

The offending argument is `asp.ratio`. This PR sets `asp.ratio` to `1` as default (as is the case in other voronoi/delaunay funcs in the pkg).