### PR TITLE
Make StatAutodensity and StatAutobin work if the data has NA values

### DIFF
--- a/R/autodensity.R
+++ b/R/autodensity.R
@@ -44,9 +44,9 @@ StatAutodensity <- ggproto('StatAutodensity', StatDensity,
   setup_params = function(data, params) {
     params$panel_range <- lapply(split(data$y, data$PANEL), function(y) {
       if (length(y) == 0) return()
-      range(y)
+      range(y, na.rm=TRUE)
     })
-    params$panel_count <- lapply(split(data$y, data$PANEL), length)
+    params$panel_count <- lapply(split(data$y, data$PANEL), function(y)length(y[is.finite(y)]))
 
     params
   },

--- a/R/autohistogram.R
+++ b/R/autohistogram.R
@@ -65,9 +65,9 @@ StatAutobin <- ggproto('StatAutobin', StatBin,
     if (is.null(params$bins)) params$bins <- 30
     params$panel_range <- lapply(split(data$y, data$PANEL), function(y) {
       if (length(y) == 0) return()
-      range(y)
+      range(y, na.rm=TRUE)
     })
-    params$panel_count <- lapply(split(data$y, data$PANEL), length)
+    params$panel_count <- lapply(split(data$y, data$PANEL), function(y)length(y[is.finite(y)]))
 
     params
   },


### PR DESCRIPTION
This closes #174. I'm not sure if this is the best approach, but as far as I understand, ggplot always removes NA values, the only difference is whether there is a user-visible warning or not (controlled by the na.rm parameter). Since the warning is produced in compute_layer() in the Stat base class, it should not be affected by this change.