### PR TITLE
Theme elements for zoom indicators

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,7 @@
 # ggforce (development version)
 
-- Cnages to comply with latest ggplot2 release
+- Changes to comply with latest ggplot2 release
+- `facet_zoom()` zoom indicators now have their own theme elements (#98)
 
 # ggforce 0.3.1
 

--- a/R/facet_zoom.R
+++ b/R/facet_zoom.R
@@ -29,7 +29,18 @@
 #'
 #' @param show.area Should the zoom area be drawn below the data points on the
 #' full data panel? Defaults to `TRUE`.
-#'
+#' 
+#' @details The looks of the zooming indicators can be controlled by using
+#'   setting the appropriate elements in `theme()`. The theme elements are
+#'   defined with `element_rect()` and affect the following parts:
+#'   * `ggforce.zoom`: All zooming indicators, both funnels and areas.
+#'   * `ggforce.zoom.funnel`: The funnel in between the panels.
+#'   * `ggforce.zoom.funnel.(x|y)`: To seperate funnels originating from the 
+#'   x- or y-axis.
+#'   * `ggforce.zoom.area`: The area on the panel indicating the limits.
+#'   * `ggforce.zoom.area.(x|y)`: To indicate ranges on the x- and y-axis 
+#'   seperately.
+#'   
 #' @inheritParams ggplot2::facet_wrap
 #'
 #' @family ggforce facets

--- a/R/facet_zoom.R
+++ b/R/facet_zoom.R
@@ -377,7 +377,7 @@ FacetZoom <- ggproto('FacetZoom', Facet,
     zoom_element_y <- calc_element("ggforce.zoom.area.y", theme)
     
     if (!(is.null(params$x) && is.null(params$xlim)) &&
-        params$show.area && !inherits(theme$zoom.x, 'element_blank')) {
+        params$show.area && !inherits(zoom_element_x, 'element_blank')) {
       zoom_prop <- rescale(x_scales[[2]]$dimension(expansion(x_scales[[2]])),
         from = x_scales[[1]]$dimension(expansion(x_scales[[1]]))
       )
@@ -393,7 +393,7 @@ FacetZoom <- ggproto('FacetZoom', Facet,
       x_back <- zeroGrob()
     }
     if (!(is.null(params$y) && is.null(params$ylim)) &&
-        params$show.area && !inherits(theme$zoom.y, 'element_blank')) {
+        params$show.area && !inherits(zoom_element_y, 'element_blank')) {
       zoom_prop <- rescale(y_scales[[2]]$dimension(expansion(y_scales[[2]])),
         from = y_scales[[1]]$dimension(expansion(y_scales[[1]]))
       )

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -5,4 +5,27 @@ default_axis_guide <- NULL
   } else {
     default_axis_guide <<- "none"
   }
+  
+  # Registering of theme elements
+  register_theme_elements(
+    ggforce.zoom = element_rect(),
+    ggforce.zoom.funnel = element_rect(),
+    ggforce.zoom.funnel.x = element_rect(),
+    ggforce.zoom.funnel.y = element_rect(),
+    ggforce.zoom.area = element_rect(),
+    ggforce.zoom.area.x = element_rect(),
+    ggforce.zoom.area.y = element_rect(),
+    element_tree = list(
+      ggforce.zoom = el_def("element_rect", "strip.background", 
+                            "zoom elements: funnels and areas"),
+      ggforce.zoom.funnel = el_def("element_rect", "ggforce.zoom",
+                                   "zoom funnel between panels"),
+      ggforce.zoom.funnel.x = el_def("element_rect", "ggforce.zoom.funnel"),
+      ggforce.zoom.funnel.y = el_def("element_rect", "ggforce.zoom.funnel"),
+      ggforce.zoom.area = el_def("element_rect", "ggforce.zoom",
+                                 "indicator area for zooming"),
+      ggforce.zoom.area.x = el_def("element_rect", "ggforce.zoom.area"),
+      ggforce.zoom.area.y = el_def("element_rect", "ggforce.zoom.area")
+    )
+  )
 }

--- a/man/facet_zoom.Rd
+++ b/man/facet_zoom.Rd
@@ -4,9 +4,19 @@
 \alias{facet_zoom}
 \title{Facet data for zoom with context}
 \usage{
-facet_zoom(x, y, xy, zoom.data, xlim = NULL, ylim = NULL,
-  split = FALSE, horizontal = TRUE, zoom.size = 2,
-  show.area = TRUE, shrink = TRUE)
+facet_zoom(
+  x,
+  y,
+  xy,
+  zoom.data,
+  xlim = NULL,
+  ylim = NULL,
+  split = FALSE,
+  horizontal = TRUE,
+  zoom.size = 2,
+  show.area = TRUE,
+  shrink = TRUE
+)
 }
 \arguments{
 \item{x, y, xy}{An expression evaluating to a logical vector that determines
@@ -44,6 +54,20 @@ will be indicated on the full dataset panel for reference. It is possible to
 zoom in on both the x and y axis at the same time. If this is done it is
 possible to both get each zoom separately and combined or just combined.
 }
+\details{
+The looks of the zooming indicators can be controlled by using
+setting the appropriate elements in \code{theme()}. The theme elements are
+defined with \code{element_rect()} and affect the following parts:
+\itemize{
+\item \code{ggforce.zoom}: All zooming indicators, both funnels and areas.
+\item \code{ggforce.zoom.funnel}: The funnel in between the panels.
+\item \code{ggforce.zoom.funnel.(x|y)}: To seperate funnels originating from the
+x- or y-axis.
+\item \code{ggforce.zoom.area}: The area on the panel indicating the limits.
+\item \code{ggforce.zoom.area.(x|y)}: To indicate ranges on the x- and y-axis
+seperately.
+}
+}
 \examples{
 # Zoom in on the versicolor species on the x-axis
 ggplot(iris, aes(Petal.Length, Petal.Width, colour = Species)) +
@@ -76,8 +100,9 @@ ggplot(iris, aes(Petal.Length, Petal.Width, colour = Species)) +
   facet_zoom(x = Species == 'versicolor', zoom.data = Species == 'versicolor')
 }
 \seealso{
-Other ggforce facets: \code{\link{facet_grid_paginate}},
-  \code{\link{facet_stereo}},
-  \code{\link{facet_wrap_paginate}}
+Other ggforce facets: 
+\code{\link{facet_grid_paginate}()},
+\code{\link{facet_stereo}()},
+\code{\link{facet_wrap_paginate}()}
 }
 \concept{ggforce facets}


### PR DESCRIPTION
As requested in #98, it would be nice to have more control over theme elements. 

Briefly, this PR introduces theme elements via the ggplot2 registration system that control the graphical parameters of the zooming elements of `facet_zoom()`.

Less briefly and with plots, here is how it would work. For compatibility reasons, the zoom elements still inherit from `strip.background`, from which an alpha is applied over the `fill` parameter.

``` r
library(ggplot2)
library(ggforce)

g <- ggplot(iris, aes(Petal.Length, Petal.Width, colour = Species)) +
  geom_point() +
  facet_zoom(xy = Species == 'versicolor', split = TRUE)

g + theme(strip.background = element_rect(fill = "red"))
```

![](https://i.imgur.com/dXd1v9B.png)

Next up is the `ggforce.zoom` element, which inherits from `strip.background` but, it doesn't apply alpha in a hardcoded manner, so that users can supply their own.

``` r

g + theme(ggforce.zoom = element_rect(fill = alpha("yellow", 0.2), 
                                      colour = "black",
                                      linetype = 2))
```

![](https://i.imgur.com/eOtJzNx.png)

To allow more precise control, this PR also adds a `ggforce.zoom.funnel` element, which controls the trapezoid between panels. It inherits from the `ggforce.zoom` element.

``` r

g + theme(ggforce.zoom.funnel = element_rect(fill = "green"))
```

![](https://i.imgur.com/iiH6euO.png)

The areas on the panels themselves are controlled by `ggforce.zoom.area` which also inherits from the `ggforce.zoom` element.

``` r

g + theme(ggforce.zoom.area = element_rect(fill = "purple"))
```

![](https://i.imgur.com/7GVafBk.png)

Finally, there are also `*.x` and `*.y` variants of the `ggforce.zoom.area` and `ggforce.zoom.funnel` elements, that inherit from these. This brings us one step closer to generative Piet Mondriaan art.

``` r

g + theme(
  ggforce.zoom.area.x = element_rect(fill = "blue", colour = "yellow"),
  ggforce.zoom.area.y = element_rect(fill = "red", colour = "green"),
  ggforce.zoom.funnel.x = element_rect(fill = "green", colour = "purple"),
  ggforce.zoom.funnel.y = element_rect(fill = "yellow", colour = "red")
)
```

![](https://i.imgur.com/q8jxDFe.png)

As a sidenote, a small thing that I imagine could happen, is that the alpha of the fill in `strip.panel.background` is reset if it is made invisible that way. But I don't think this is a big problem as there are finer control now.

``` r

g + theme(strip.background = element_rect(fill = alpha("red", 0)))
```

![](https://i.imgur.com/9ZNPUgf.png)

<sup>Created on 2020-05-14 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0)</sup>
