### PR TITLE
fix scale_unit example for next units v0.7-0

### DIFF
--- a/R/scale-unit.R
+++ b/R/scale-unit.R
@@ -16,9 +16,8 @@
 #'
 #' @examples
 #' library(units)
-#' gallon <- as_units('gallon')
-#' mtcars$consumption <- mtcars$mpg * with(ud_units, mi / gallon)
-#' mtcars$power <- mtcars$hp * with(ud_units, hp)
+#' mtcars$consumption <- set_units(mtcars$mpg, mi / gallon)
+#' mtcars$power <- set_units(mtcars$hp, hp)
 #'
 #' # Use units encoded into the data
 #' ggplot(mtcars) +

--- a/man/scale_unit.Rd
+++ b/man/scale_unit.Rd
@@ -130,9 +130,8 @@ usually be added automatically. To override manually, use
 }
 \examples{
 library(units)
-gallon <- as_units('gallon')
-mtcars$consumption <- mtcars$mpg * with(ud_units, mi / gallon)
-mtcars$power <- mtcars$hp * with(ud_units, hp)
+mtcars$consumption <- set_units(mtcars$mpg, mi / gallon)
+mtcars$power <- set_units(mtcars$hp, hp)
 
 # Use units encoded into the data
 ggplot(mtcars) +


### PR DESCRIPTION
We are working on `units` v0.7-0, which drops some stuff that has been deprecated for almost 3 years. This patch fixes the example in `scale_unit` that was using one of those objects.