### PR TITLE
Stop ordering of shapes from being changed by `arcPaths`. 

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,7 @@
 # ggforce (development version)
 
 - Changed documentation to comply with new units package
+- Fixed unintentional re-ordering of shapes (#224)
 
 # ggforce 0.3.2
 

--- a/R/arc_bar.R
+++ b/R/arc_bar.R
@@ -185,13 +185,23 @@ geom_arc_bar <- function(mapping = NULL, data = NULL, stat = 'arc_bar',
   )
 }
 
+# This function is like base::make.unique, but it
+# maintains the ordering of the original names if the values
+# are sorted.
+
+make_unique <- function(names, sep = ".") {
+  n <- length(names)
+  width <- floor(log10(n)) + 1
+  sprintf("%s%s%0*d", names, sep, width, seq_len(n))
+}
+
 arcPaths <- function(data, n) {
   trans <- radial_trans(c(0, 1), c(0, 2 * pi), pad = 0)
   data <- data[data$start != data$end, ]
   data$nControl <- ceiling(n / (2 * pi) * abs(data$end - data$start))
   data$nControl[data$nControl < 3] <- 3
   extraData <- !names(data) %in% c('r0', 'r', 'start', 'end', 'group')
-  data$group <- make.unique(as.character(data$group))
+  data$group <- make_unique(as.character(data$group))
   paths <- lapply(seq_len(nrow(data)), function(i) {
     path <- data.frame(
       a = seq(data$start[i], data$end[i], length.out = data$nControl[i]),

--- a/R/diagonal.R
+++ b/R/diagonal.R
@@ -98,7 +98,7 @@ StatDiagonal <- ggproto('StatDiagonal', Stat,
   },
   compute_panel = function(data, scales, n = 100, strength = 0.5) {
     if (is.null(data)) return(data)
-    data$group <- make.unique(as.character(data$group))
+    data$group <- make_unique(as.character(data$group))
     end <- data
     end$x <- end$xend
     end$y <- end$yend
@@ -184,7 +184,7 @@ geom_diagonal2 <- function(mapping = NULL, data = NULL, stat = 'diagonal2',
 StatDiagonal0 <- ggproto('StatDiagonal0', Stat,
   compute_panel = function(data, scales, strength = 0.5) {
     if (is.null(data)) return(data)
-    data$group <- make.unique(as.character(data$group))
+    data$group <- make_unique(as.character(data$group))
     end <- data
     end$x <- end$xend
     end$y <- end$yend

--- a/R/ellipse.R
+++ b/R/ellipse.R
@@ -69,7 +69,7 @@ StatEllip <- ggproto('StatEllip', Stat,
   },
   compute_panel = function(self, data, scales, n = 360) {
     if (is.null(data)) return(data)
-    data$group <- make.unique(as.character(data$group))
+    data$group <- make_unique(as.character(data$group))
     n_ellipses <- nrow(data)
     data <- data[rep(seq_len(n_ellipses), each = n), ]
     points <- rep(seq(0, 2 * pi, length.out = n + 1)[seq_len(n)],

--- a/R/link.R
+++ b/R/link.R
@@ -107,7 +107,7 @@ StatLink <- ggproto('StatLink', Stat,
   },
   compute_panel = function(data, scales, n = 100) {
     extraCols <- !names(data) %in% c('x', 'y', 'xend', 'yend', 'group', 'PANEL')
-    data$group <- make.unique(as.character(data$group))
+    data$group <- make_unique(as.character(data$group))
     data <- lapply(seq_len(nrow(data)), function(i) {
       path <- data.frame(
         x = seq(data$x[i], data$xend[i], length.out = n),

--- a/R/regon.R
+++ b/R/regon.R
@@ -60,7 +60,7 @@ StatRegon <- ggproto('StatRegon', Stat,
       if (n %% 2 == 0) p <- p + p[2] / 2
       p * 2 * pi
     }))
-    data$group <- make.unique(as.character(data$group))
+    data$group <- make_unique(as.character(data$group))
     data <- data[rep(seq_len(nrow(data)), data$sides), ]
     x_tmp <- sin(pos) * data$r
     y_tmp <- cos(pos) * data$r

--- a/R/spiro.R
+++ b/R/spiro.R
@@ -68,7 +68,7 @@ StatSpiro <- ggproto('StatSpiro', Stat,
     if (is.null(data$x0)) data$x0 <- 0
     if (is.null(data$y0)) data$y0 <- 0
     n_spiro <- nrow(data)
-    data$group <- make.unique(as.character(data$group))
+    data$group <- make_unique(as.character(data$group))
     if (is.null(revolutions)) {
       revo <- attr(fractions(data$r / data$R), 'fracs')
       revo <- as.numeric(sub('/.*$', '', revo))


### PR DESCRIPTION
This adds a function `make_unique()` to be used instead of `base::make.unique()` so the ordering of the elements is not changed by `arcPaths`.  Fixes issue #224.