### PR TITLE
various documentation fixes for mark* functions

### DIFF
--- a/R/mark_circle.R
+++ b/R/mark_circle.R
@@ -7,7 +7,7 @@
 #' to better enclose the points.
 #'
 #' @section Annotation:
-#' All `geom_mark_*` allows you to put descriptive textboxes connected to the
+#' All `geom_mark_*` allow you to put descriptive textboxes connected to the
 #' mark on the plot, using the `label` and `description` aesthetics. The
 #' textboxes are automatically placed close to the mark, but without obscuring
 #' any of the datapoints in the layer. The placement is dynamic so if you resize
@@ -47,14 +47,14 @@
 #'
 #' @inheritParams geom_shape
 #'
-#' @param n The number of points used to draw each circle. Defaults to `100`
+#' @param n The number of points used to draw each circle. Defaults to `100`.
 #' @param label.margin The margin around the annotation boxes, given by a call
-#' to [ggplot2::margin()]
+#' to [ggplot2::margin()].
 #' @param label.width A fixed width for the label. Set to `NULL` to let the text
-#' or `label.minwidth` decide
+#' or `label.minwidth` decide.
 #' @param label.minwidth The minimum width to provide for the description. If
-#' the size of the label exceeds this, the the description is allowed to fill as
-#' much as the label
+#' the size of the label exceeds this, the description is allowed to fill as
+#' much as the label.
 #' @param label.fontsize The size of the text for the annotation. If it contains
 #' two elements the first will be used for the label and the second for the
 #' description.
@@ -77,17 +77,17 @@
 #' @param label.buffer The size of the region around the mark where labels
 #' cannot be placed.
 #' @param con.colour The colour for the line connecting the annotation to the
-#' mark
-#' @param con.size The width of the connector
+#' mark.
+#' @param con.size The width of the connector.
 #' @param con.type The type of the connector. Either `"elbow"`, `"straight"`, or
 #' `"none"`.
-#' @param con.linetype The linetype of the connector
+#' @param con.linetype The linetype of the connector.
 #' @param con.border The bordertype of the connector. Either `"one"` (to draw a
 #' line on the horizontal side closest to the mark), `"all"` (to draw a border
-#' on all sides), or `"none"` (not going to explain that one)
+#' on all sides), or `"none"` (not going to explain that one).
 #' @param con.cap The distance before the mark that the line should stop at.
 #' @param con.arrow An arrow specification for the connection using
-#' [grid::arrow()] for the end pointing towards the mark
+#' [grid::arrow()] for the end pointing towards the mark.
 #'
 #' @family mark geoms
 #'

--- a/R/mark_ellipse.R
+++ b/R/mark_ellipse.R
@@ -1,7 +1,7 @@
 #' Annotate areas with ellipses
 #'
 #' This geom lets you annotate sets of points via ellipses. The enclosing
-#' ellipses are estimated using the Khachiyan algorithm which guarantees and
+#' ellipses are estimated using the Khachiyan algorithm which guarantees an
 #' optimal solution within the given tolerance level. As this geom is often
 #' expanded it is of lesser concern that some points are slightly outside the
 #' ellipsis. The Khachiyan algorithm has polynomial complexity and can thus
@@ -12,7 +12,7 @@
 #' @inheritSection geom_mark_circle Annotation
 #' @inheritSection geom_mark_circle Filtering
 #' @section Aesthetics:
-#' geom_mark_ellipse understand the following aesthetics (required aesthetics are
+#' `geom_mark_ellipse` understand the following aesthetics (required aesthetics are
 #' in bold):
 #'
 #' - **x**

--- a/R/mark_ellipse.R
+++ b/R/mark_ellipse.R
@@ -29,7 +29,7 @@
 #'
 #' @inheritParams geom_mark_circle
 #'
-#' @param n The number of points used to draw each circle. Defaults to `100`.
+#' @param n The number of points used to draw each ellipse. Defaults to `100`.
 #' @param tol The tolerance cutoff. Lower values will result in ellipses closer
 #' to the optimal solution. Defaults to `0.01`.
 #'

--- a/R/mark_ellipse.R
+++ b/R/mark_ellipse.R
@@ -12,7 +12,7 @@
 #' @inheritSection geom_mark_circle Annotation
 #' @inheritSection geom_mark_circle Filtering
 #' @section Aesthetics:
-#' `geom_mark_ellipse` understand the following aesthetics (required aesthetics are
+#' `geom_mark_ellipse` understands the following aesthetics (required aesthetics are
 #' in bold):
 #'
 #' - **x**
@@ -29,9 +29,9 @@
 #'
 #' @inheritParams geom_mark_circle
 #'
-#' @param n The number of points used to draw each circle. Defaults to `100`
+#' @param n The number of points used to draw each circle. Defaults to `100`.
 #' @param tol The tolerance cutoff. Lower values will result in ellipses closer
-#' to the optimal solution. Defaults to `0.01`
+#' to the optimal solution. Defaults to `0.01`.
 #'
 #' @family mark geoms
 #'

--- a/R/mark_hull.R
+++ b/R/mark_hull.R
@@ -29,8 +29,8 @@
 #'
 #' @inheritParams geom_mark_circle
 #'
-#' @param concavity A meassure of the concavity of the hull. `1` is very concave
-#' while it approaches convex as it grows. Defaults to `2`
+#' @param concavity A measure of the concavity of the hull. `1` is very concave
+#' while it approaches convex as it grows. Defaults to `2`.
 #'
 #' @family mark geoms
 #' @name geom_mark_hull

--- a/R/mark_hull.R
+++ b/R/mark_hull.R
@@ -12,7 +12,7 @@
 #' @inheritSection geom_mark_circle Annotation
 #' @inheritSection geom_mark_circle Filtering
 #' @section Aesthetics:
-#' geom_mark_hull understand the following aesthetics (required aesthetics are
+#' `geom_mark_hull` understand the following aesthetics (required aesthetics are
 #' in bold):
 #'
 #' - **x**

--- a/R/mark_rect.R
+++ b/R/mark_rect.R
@@ -1,13 +1,13 @@
 #' Annotate areas with rectangles
 #'
 #' This geom lets you annotate sets of points via rectangles. The rectangles are
-#' simply scaled to the range of the data and as with the the other
+#' simply scaled to the range of the data and as with the other
 #' `geom_mark_*()` geoms expanded and have rounded corners.
 #'
 #' @inheritSection geom_mark_circle Annotation
 #' @inheritSection geom_mark_circle Filtering
 #' @section Aesthetics:
-#' geom_mark_rect understand the following aesthetics (required aesthetics are
+#' `geom_mark_rect` understands the following aesthetics (required aesthetics are
 #' in bold):
 #'
 #' - **x**


### PR DESCRIPTION
Excuse the numerous commits, I am doing this straight from GitHub (I thought it would be one typo, and I ended up spotting more things)

Not built and tested locally as they are documentation fixes, code wasn't touched.