### PR TITLE
Add support for nudge_x/nudge_y in geom_parallel_sets_labels

### DIFF
--- a/R/parallel_sets.R
+++ b/R/parallel_sets.R
@@ -35,6 +35,8 @@
 #' @param sep The proportional separation between categories within a variable
 #' @param axis.width The width of the area around each variable axis
 #' @param angle The angle of the axis label text
+#' @param nudge_x,nudge_y Horizontal and vertical adjustment to nudge labels by.
+#' Useful for offsetting text from the category segments.
 #'
 #' @name geom_parallel_sets
 #' @rdname geom_parallel_sets
@@ -49,6 +51,12 @@
 #'   geom_parallel_sets(aes(fill = Sex), alpha = 0.3, axis.width = 0.1) +
 #'   geom_parallel_sets_axes(axis.width = 0.1) +
 #'   geom_parallel_sets_labels(colour = 'white')
+#'
+#' # Use nudge_x to offset and hjust = 0 to left-justify label
+#' ggplot(data, aes(x, id = id, split = y, value = value)) +
+#'   geom_parallel_sets(aes(fill = Sex), alpha = 0.3, axis.width = 0.1) +
+#'   geom_parallel_sets_axes(axis.width = 0.1) +
+#'   geom_parallel_sets_labels(colour = 'red', angle = 0, nudge_x = 0.1, hjust = 0)
 NULL
 
 #' @rdname ggforce-extensions
@@ -215,9 +223,15 @@ geom_parallel_sets_axes <- function(mapping = NULL, data = NULL,
 #' @export
 geom_parallel_sets_labels <- function(mapping = NULL, data = NULL,
                                       stat = 'parallel_sets_axes', angle = -90,
+				      nudge_x = 0, nudge_y = 0,
                                       position = 'identity', na.rm = FALSE,
                                       show.legend = NA, inherit.aes = TRUE,
                                       ...) {
+  if (!missing(nudge_x) || !missing(nudge_y)) {
+    if (!missing(position)) die("You must specify either `position` or `nudge_x`/`nudge_y`.")
+    position <- position_nudge(nudge_x, nudge_y)
+  }
+
   layer(
     data = data, mapping = mapping, stat = stat, geom = GeomText,
     position = position, show.legend = show.legend, inherit.aes = inherit.aes,

--- a/R/parallel_sets.R
+++ b/R/parallel_sets.R
@@ -228,7 +228,7 @@ geom_parallel_sets_labels <- function(mapping = NULL, data = NULL,
                                       show.legend = NA, inherit.aes = TRUE,
                                       ...) {
   if (!missing(nudge_x) || !missing(nudge_y)) {
-    if (!missing(position)) die("You must specify either `position` or `nudge_x`/`nudge_y`.")
+    if (!missing(position)) stop("You must specify either `position` or `nudge_x`/`nudge_y`.", call. = FALSE)
     position <- position_nudge(nudge_x, nudge_y)
   }
 

--- a/man/geom_parallel_sets.Rd
+++ b/man/geom_parallel_sets.Rd
@@ -67,6 +67,8 @@ geom_parallel_sets_labels(
   data = NULL,
   stat = "parallel_sets_axes",
   angle = -90,
+  nudge_x = 0,
+  nudge_y = 0,
   position = "identity",
   na.rm = FALSE,
   show.legend = NA,
@@ -132,6 +134,9 @@ to the paired geom/stat.}
 layer, as a string.}
 
 \item{angle}{The angle of the axis label text}
+
+\item{nudge_x, nudge_y}{Horizontal and vertical adjustment to nudge labels by.
+Useful for offsetting text from the category segments.}
 }
 \description{
 A parallel sets diagram is a type of visualisation showing the interaction
@@ -177,6 +182,12 @@ ggplot(data, aes(x, id = id, split = y, value = value)) +
   geom_parallel_sets(aes(fill = Sex), alpha = 0.3, axis.width = 0.1) +
   geom_parallel_sets_axes(axis.width = 0.1) +
   geom_parallel_sets_labels(colour = 'white')
+
+# Use nudge_x to offset and hjust = 0 to left-justify label
+ggplot(data, aes(x, id = id, split = y, value = value)) +
+  geom_parallel_sets(aes(fill = Sex), alpha = 0.3, axis.width = 0.1) +
+  geom_parallel_sets_axes(axis.width = 0.1) +
+  geom_parallel_sets_labels(colour = 'red', angle = 0, nudge_x = 0.1, hjust = 0)
 }
 \author{
 Thomas Lin Pedersen


### PR DESCRIPTION
This PR adds support for using `nudge_x` and `nudge_y` in `geom_parallel_sets_labels` when creating parallel sets diagrams. It is especially useful when the labels are too long to fit inside the bars depicting the discrete categories. 

This enhancement allows the labels to be placed beside the categories.

``` r
library(ggforce)
#> Loading required package: ggplot2
data <- reshape2::melt(Titanic)
data <- gather_set_data(data, 1:4)

ggplot(data, aes(x, id = id, split = y, value = value)) +
  geom_parallel_sets(aes(fill = Sex), alpha = 0.3, axis.width = 0.1) +
  geom_parallel_sets_axes(axis.width = 0.1) +
  geom_parallel_sets_labels(colour = 'white')
```

![](https://i.imgur.com/ZUvP8ig.png)

``` r

# Use nudge_x to offset and hjust = 0 to left-justify label
ggplot(data, aes(x, id = id, split = y, value = value)) +
  geom_parallel_sets(aes(fill = Sex), alpha = 0.3, axis.width = 0.1) +
  geom_parallel_sets_axes(axis.width = 0.1) +
  geom_parallel_sets_labels(colour = 'red', angle = 0, nudge_x = 0.1, hjust = 0)
```

![](https://i.imgur.com/AbDrJjh.png)

<sup>Created on 2022-04-05 by the [reprex package](https://reprex.tidyverse.org) (v2.0.1)</sup>
