### PR TITLE
Update 'units' required version

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -49,7 +49,7 @@ Suggests:
     deldir,
     latex2exp,
     reshape2,
-    units (>= 0.4-6),
+    units (>= 0.8.0),
     covr
 Collate: 
     'RcppExports.R'


### PR DESCRIPTION
`units::scale_{x,y}_units()` weren't available until at least v0.8.0:

https://github.com/thomasp85/ggforce/blob/9be635c582559f016254b111770a61e4b4aa0958/R/scale-unit.R#L17-L29

https://github.com/r-quantities/units/tree/a8f896ffc91f6c71e85d6150abe4a00bfed7ff2f