### PR TITLE
feat: Use `ggplot2::fill_alpha()` for adjusting fill alphas

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -21,7 +21,7 @@ BugReports: https://github.com/thomasp85/ggforce/issues
 License: MIT + file LICENSE
 Encoding: UTF-8
 Depends:
-    ggplot2 (>= 3.3.6),
+    ggplot2 (>= 3.5.0),
     R (>= 3.3.0)
 Imports:
     grid,

--- a/R/bspline_closed.R
+++ b/R/bspline_closed.R
@@ -102,7 +102,7 @@ GeomBsplineClosed0 <- ggproto('GeomBspline0', GeomPolygon,
       shape = 1, open = FALSE,
       gp = gpar(
         col = coords$colour[startPoint],
-        fill = alpha(coords$fill[startPoint], coords$alpha[startPoint]),
+        fill = ggplot2::fill_alpha(coords$fill[startPoint], coords$alpha[startPoint]),
         lwd = (coords$linewidth[startPoint] %||% coords$size[startPoint]) * .pt,
         lty = coords$linetype[startPoint]
       )

--- a/R/facet_zoom.R
+++ b/R/facet_zoom.R
@@ -234,7 +234,7 @@ FacetZoom <- ggproto('FacetZoom', Facet,
         indicator <- polygonGrob(
           c(1, 1, 0, 0),
           c(zoom_prop, 1, 0),
-          gp = gpar(col = NA, fill = alpha(zoom_y$fill, 0.5))
+          gp = gpar(col = NA, fill = ggplot2::fill_alpha(zoom_y$fill, 0.5))
         )
         lines <- segmentsGrob(
           y0 = c(0, 1),
@@ -261,7 +261,7 @@ FacetZoom <- ggproto('FacetZoom', Facet,
         indicator <- polygonGrob(
           c(zoom_prop, 1, 0),
           c(1, 1, 0, 0),
-          gp = gpar(col = NA, fill = alpha(zoom_x$fill, 0.5))
+          gp = gpar(col = NA, fill = ggplot2::fill_alpha(zoom_x$fill, 0.5))
         )
         lines <- segmentsGrob(
           x0 = c(0, 1),
@@ -365,7 +365,7 @@ FacetZoom <- ggproto('FacetZoom', Facet,
       x_back <- grobTree(
         rectGrob(x = mean(zoom_prop), y = 0.5, width = diff(zoom_prop),
                  height = 1,
-                 gp = gpar(col = NA, fill = alpha(zoom_x$fill, 0.5))),
+                 gp = gpar(col = NA, fill = ggplot2::fill_alpha(zoom_x$fill, 0.5))),
         segmentsGrob(zoom_prop, c(0, 0), zoom_prop, c(1, 1), gp = gpar(
           col = zoom_x$colour,
           lty = zoom_x$linetype,
@@ -384,7 +384,7 @@ FacetZoom <- ggproto('FacetZoom', Facet,
       y_back <- grobTree(
         rectGrob(y = mean(zoom_prop), x = 0.5, height = diff(zoom_prop),
                  width = 1,
-                 gp = gpar(col = NA, fill = alpha(zoom_y$fill, 0.5))),
+                 gp = gpar(col = NA, fill = ggplot2::fill_alpha(zoom_y$fill, 0.5))),
         segmentsGrob(y0 = zoom_prop, x0 = c(0, 0), y1 = zoom_prop, x1 = c(1, 1),
                      gp = gpar(col = zoom_y$colour,
                                lty = zoom_y$linetype,

--- a/R/interpolate.R
+++ b/R/interpolate.R
@@ -47,7 +47,7 @@ GeomPathInterpolate <- ggproto('GeomPathInterpolate', GeomPath,
         default.units = 'native', arrow = arrow,
         gp = gpar(
           col = alpha(munched$colour, munched$alpha)[!end],
-          fill = alpha(munched$colour, munched$alpha)[!end],
+          fill = ggplot2::fill_alpha(munched$colour[!end], munched$alpha[!end]),
           lwd = (munched$linewidth[!end] %||% munched$size[!end]) * .pt,
           lty = munched$linetype[!end],
           lineend = lineend, linejoin = linejoin, linemitre = linemitre
@@ -60,7 +60,7 @@ GeomPathInterpolate <- ggproto('GeomPathInterpolate', GeomPath,
         id = id, default.units = 'native',
         arrow = arrow, gp = gpar(
           col = alpha(munched$colour, munched$alpha)[start],
-          fill = alpha(munched$colour, munched$alpha)[start],
+          fill = ggplot2::fill_alpha(munched$colour[start], munched$alpha[start]),
           lwd = (munched$linewidth[start] %||% munched$size[start]) * .pt,
           lty = munched$linetype[start], lineend = lineend,
           linejoin = linejoin, linemitre = linemitre

--- a/R/mark_circle.R
+++ b/R/mark_circle.R
@@ -203,7 +203,7 @@ GeomMarkCircle <- ggproto('GeomMarkCircle', GeomShape,
 
     gp <- gpar(
       col = first_rows$colour,
-      fill = alpha(first_rows$fill, first_rows$alpha),
+      fill = ggplot2::fill_alpha(first_rows$fill, first_rows$alpha),
       lwd = (first_rows$linewidth %||% first_rows$size) * .pt,
       lty = first_rows$linetype,
       fontsize = (first_rows$size %||% 4.217518) * .pt

--- a/R/mark_ellipse.R
+++ b/R/mark_ellipse.R
@@ -132,7 +132,7 @@ GeomMarkEllipse <- ggproto('GeomMarkEllipse', GeomMarkCircle,
 
     gp <- gpar(
       col = first_rows$colour,
-      fill = alpha(first_rows$fill, first_rows$alpha),
+      fill = ggplot2::fill_alpha(first_rows$fill, first_rows$alpha),
       lwd = (first_rows$linewidth %||% first_rows$size) * .pt,
       lty = first_rows$linetype,
       fontsize = (first_rows$size %||% 4.217518) * .pt

--- a/R/mark_hull.R
+++ b/R/mark_hull.R
@@ -144,7 +144,7 @@ GeomMarkHull <- ggproto('GeomMarkHull', GeomMarkCircle,
 
     gp <- gpar(
       col = first_rows$colour,
-      fill = alpha(first_rows$fill, first_rows$alpha),
+      fill = ggplot2::fill_alpha(first_rows$fill, first_rows$alpha),
       lwd = (first_rows$linewidth %||% first_rows$size) * .pt,
       lty = first_rows$linetype,
       fontsize = (first_rows$size %||% 4.217518) * .pt

--- a/R/mark_rect.R
+++ b/R/mark_rect.R
@@ -143,7 +143,7 @@ GeomMarkRect <- ggproto('GeomMarkRect', GeomMarkCircle,
 
     gp <- gpar(
       col = first_rows$colour,
-      fill = alpha(first_rows$fill, first_rows$alpha),
+      fill = ggplot2::fill_alpha(first_rows$fill, first_rows$alpha),
       lwd = (first_rows$linewidth %||% first_rows$size) * .pt,
       lty = first_rows$linetype,
       fontsize = (first_rows$size %||% 4.217518) * .pt

--- a/R/shape.R
+++ b/R/shape.R
@@ -89,7 +89,7 @@ GeomShape <- ggproto('GeomShape', GeomPolygon,
       id = munched$group, expand = expand, radius = radius,
       gp = gpar(
         col = first_rows$colour,
-        fill = alpha(first_rows$fill, first_rows$alpha),
+        fill = ggplot2::fill_alpha(first_rows$fill, first_rows$alpha),
         lwd = (first_rows$linewidth %||% first_rows$size) * .pt,
         lty = first_rows$linetype
       )


### PR DESCRIPTION
* Bumps required {ggplot2} to v3.5.0 when `fill_alpha()` was introduced.
* Replace each `fill = alpha(fill, alpha)` with `fill = fill_alpha(fill, alpha)`.

closes #323