### PR TITLE
remove extra spacing requirement around label bounding box

### DIFF
--- a/R/mark_label.R
+++ b/R/mark_label.R
@@ -67,7 +67,7 @@ place_labels <- function(rects, polygons, bounds, anchors, ghosts) {
     res[[i]] <- closest$proj
     rect$x <- rect$x + closest$proj[1]
     rect$y <- rect$y + closest$proj[2]
-    polygons[[length(polygons) + 1]] <- polyoffset(rect, 10)
+    polygons[[length(polygons) + 1]] <- rect
   }
   res
 }


### PR DESCRIPTION
Fixes #334

Currently the extra spacing is added during the label placement. However, users can already set label padding by setting `label.margin` option, which is used when creating label bounding boxes (`rect`).