### PR TITLE
Compatibility ggplot2 4.0.0

### DIFF
--- a/R/facet_matrix.R
+++ b/R/facet_matrix.R
@@ -102,7 +102,7 @@ facet_matrix <- function(rows, cols = rows, shrink = TRUE, switch = NULL,
   if (!is_quosures(rows)) rows <- quos(rows)
   if (!is_quosures(cols)) cols <- quos(cols)
 
-  labeller <- utils::getFromNamespace('check_labeller', 'ggplot2')(labeller)
+  labeller <- match.fun(labeller)
 
   ggproto(NULL, FacetMatrix,
     shrink = shrink,


### PR DESCRIPTION
Hi Thomas,

This is a small adjustment that ggforce would need to be compatible with ggplot2 4.0.0.
We renamed `ggplot2:::check_labeller()` to `ggplot2:::validate_labeller()`. That is just a deprecation wrapper for features retired in ggplot2 2.0.0, so I figured ggforce would just need the function matching.